### PR TITLE
Fix coaster endpoint response

### DIFF
--- a/api/coasters.py
+++ b/api/coasters.py
@@ -19,4 +19,7 @@ def get_coaster(coaster_id: int, db: Session = Depends(get_db)):
     coaster = db.query(Coaster).filter(Coaster.id == coaster_id).first()
     if not coaster:
         raise HTTPException(status_code=404, detail="Coaster not found")
-    return coaster, 200
+    # FastAPI automatically handles status codes for successful responses.
+    # Returning a tuple here results in an unexpected response body. Instead,
+    # return just the coaster instance so FastAPI can serialize it correctly.
+    return coaster


### PR DESCRIPTION
## Summary
- fix `get_coaster` endpoint to return the Coaster object instead of a tuple

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6840c7a44c908325a4f211d8e6e4a91b